### PR TITLE
enable semantic version gradle plugin, more...

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,6 @@ android {
         applicationId "com.example.versioningdemo"
         minSdk 24
         targetSdk 33
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -29,6 +27,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/app/src/main/java/com/example/versioningdemo/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/versioningdemo/ui/main/MainFragment.kt
@@ -1,14 +1,18 @@
 package com.example.versioningdemo.ui.main
 
-import androidx.lifecycle.ViewModelProvider
+import android.content.pm.PackageManager
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import com.example.versioningdemo.R
+import com.example.versioningdemo.databinding.FragmentMainBinding
 
 class MainFragment : Fragment() {
+
+    private lateinit var binding: FragmentMainBinding
 
     companion object {
         fun newInstance() = MainFragment()
@@ -20,13 +24,52 @@ class MainFragment : Fragment() {
         super.onCreate(savedInstanceState)
         viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
         // TODO: Use the ViewModel
+
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return inflater.inflate(R.layout.fragment_main, container, false)
+//        return inflater.inflate(R.layout.fragment_main, container, false)
+
+        // Inflate the layout for this fragment
+        binding = FragmentMainBinding.inflate(inflater, container, false)
+
+        getApplicationVersion()
+
+        return binding.root
+    }
+
+    /**
+     * Get application version and display it in the UI
+     */
+    private fun getApplicationVersion() {
+////        Get app version from build.gradle
+//        val versionName = BuildConfig.VERSION_NAME
+//        val versionCode = BuildConfig.VERSION_CODE
+
+//         Or, get app version from Android OS
+        val versionName = context?.packageManager?.getPackageInfo(
+            requireContext().packageName,
+            PackageManager.GET_ACTIVITIES
+        )?.versionName
+
+////         Or, get app code from Android OS
+//        val versionCode = context?.packageManager?.getPackageInfo(
+//            requireContext().packageName,
+//            PackageManager.GET_ACTIVITIES
+//        )?.longVersionCode // minimum API level 28
+
+//         Or, get app code from Android OS
+        val versionCode = context?.packageManager?.getPackageInfo(
+            requireContext().packageName,
+            PackageManager.GET_ACTIVITIES
+        )?.versionCode
+
+//        Set app version into textView
+        binding.textViewVersionName.text = getString(R.string.application_version, versionName)
+        binding.textViewVersionCode.text = getString(R.string.application_code, versionCode)
     }
 
 }

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -8,13 +8,31 @@
     tools:context=".ui.main.MainFragment">
 
     <TextView
-        android:id="@+id/message"
+        android:id="@+id/text_view_app_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="MainFragment"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:text="MainFragment" />
+
+    <TextView
+        android:id="@+id/text_view_version_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="@id/text_view_app_name"
+        app:layout_constraintStart_toStartOf="@id/text_view_app_name"
+        app:layout_constraintTop_toBottomOf="@id/text_view_app_name"
+        tools:text="Version 0.0.0" />
+
+    <TextView
+        android:id="@+id/text_view_version_code"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="@id/text_view_version_name"
+        app:layout_constraintStart_toStartOf="@id/text_view_version_name"
+        app:layout_constraintTop_toBottomOf="@id/text_view_version_name"
+        tools:text="Version Code 0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Versioning Demo</string>
+
+    <!--    MainFragment.kt -->
+    <string name="application_version">"Application version: %1$s"</string>
+    <string name="application_code">"Application code: %1$d"</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,9 @@ plugins {
     id 'com.android.application' version '7.4.0-rc03' apply false
     id 'com.android.library' version '7.4.0-rc03' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
+    id 'com.dipien.android.semantic-version' version '1.4.1' apply false
 }
+
+version = "0.1.0"
+
+apply plugin: "com.dipien.android.semantic-version"


### PR DESCRIPTION
- set first application version as 0.1.0 (in project build.gradle file)
- remove explicit 'versionCode' and 'versionName' fields in app build.gradle file
- enable android semantic version gradle plugin '1.4.1' in root build.gradle
- enable viewBinding
- add getApplicationVersion() function to retrieve and display version information in our fragment and UI/layout
- add string resources
- add android semantic-version plugin (by dipien)